### PR TITLE
try: Add a NoError predicate

### DIFF
--- a/try/adapters.go
+++ b/try/adapters.go
@@ -53,3 +53,8 @@ func OK[T any](it iter.Seq[T]) iter.Seq2[T, error] {
 		}
 	}
 }
+
+// NoError returns true if err is nil.
+func NoError[T any](_ T, err error) bool {
+	return err == nil
+}


### PR DESCRIPTION
This can be combined with try.Filter to filter a try-able list to only those values that do not have an associated error.